### PR TITLE
Add better support for keyboard users

### DIFF
--- a/jira/css/popup.css
+++ b/jira/css/popup.css
@@ -34,3 +34,7 @@ body {
   text-shadow: 0 1px 0 rgb(240, 240, 240);
   user-select: none;
 }
+
+.rule-button:focus {
+  border: 1px solid rgba(0, 0, 0, 0.50);
+}

--- a/jira/js/popup.js
+++ b/jira/js/popup.js
@@ -26,6 +26,11 @@ function addRuleButton(name, value) {
 
 function addRules(data){
   data.forEach(function(rule) { addRuleButton(rule.name, rule.content) });
+  // focus the first rule for keyboard users
+  let firstRuleElement = document.getElementById('rules').firstElementChild;
+  if (firstRuleElement != null) {
+    firstRuleElement.focus();
+  }
 }
 
 


### PR DESCRIPTION
I noticed that you can pop-up the extension via keyboard shortcut, but if you have multiple rules, there was no indicator for which rule was focused.  These changes both set the focus to the first rule - by default, nothing was focused previously - and adds an indicator so that you can see which rule is focused:

![image](https://user-images.githubusercontent.com/3211021/52983181-811d8680-33af-11e9-8587-739a2c3d4cba.png)

It's a subtle indicator, but you can see the middle item is selected.

Note that this does change the appearance if you use the mouse, since now the first item will have a slightly different border - since it's the item that's focused:

![image](https://user-images.githubusercontent.com/3211021/52983223-b3c77f00-33af-11e9-9b10-2f5772eaef01.png)

Hopefully that's alright